### PR TITLE
Add binary files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,11 @@ latex/
 *.su
 *.idb
 *.pdb
+
+# Anything in bin/
+bin/
+
+# Built packages
+smokerand*.gz
+smokerand_*.deb
+smokerand_*/usr/


### PR DESCRIPTION
I use [perl-git-prompt](https://github.com/scottchiefbaker/perl-git-prompt) to show me what files are eligible for check-in. After a make/build 14 files show up as potential candidates. 

This PR adds any binary files to the `.gitignore` so they don't accidentally get checked in.