### PR TITLE
Correct the pcg64_64 implementation. Fixes #14

### DIFF
--- a/generators/pcg64_64.c
+++ b/generators/pcg64_64.c
@@ -24,20 +24,20 @@
 
 PRNG_CMODULE_PROLOG
 
-typedef Lcg64State Pcg64State;
+typedef struct { uint64_t state;  uint64_t inc; } Pcg64State;
 
 static inline uint64_t get_bits_raw(Pcg64State *obj)
 {
-    const uint64_t word = ((obj->x >> ((obj->x >> 59) + 5)) ^ obj->x) *
-        12605985483714917081ull;
-    obj->x = obj->x * 6364136223846793005ull + 1442695040888963407ull;
+    uint64_t word = ((obj->state >> ((obj->state >> 59) + 5)) ^ obj->state) * 12605985483714917081ull;
+    obj->state = obj->state * 6364136223846793005ull + obj->inc;
     return (word >> 43) ^ word;
 }
 
 static void *create(const CallerAPI *intf)
 {
     Pcg64State *obj = intf->malloc(sizeof(Pcg64State));
-    obj->x = intf->get_seed64();
+    obj->state = intf->get_seed64();
+    obj->inc   = intf->get_seed64();
     return (void *) obj;
 }
 


### PR DESCRIPTION
Use the full state and increment from the pcg64 typedef. Previously we were adding a static value as the increment, this will use the value from the state. This should be more real-world and give a better idea of performance.